### PR TITLE
Add Git-backed TIGRIS reproduction workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,14 @@ Results/regression_summary.txt
 Miscilleneous
 Code_1
 Data_1
+
+# Local and cluster-generated files
+.DS_Store
+._*
+__pycache__/
+*.py[cod]
+.cache/
+logs/
+runs/
+code/deep_learning/checkpoint/
+reproduction/results/

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ python human_rating_agreement_unified.py     # Tables 7-10: inter-rater agreemen
 
 Results saved to `results/human_survey/`.
 
+### Reproducible TIGRIS execution
+
+The fixed-seed baseline wrapper, completed validation report, and Git-backed
+TIGRIS synchronization scripts are documented in
+[`reproduction/README.md`](reproduction/README.md). GPU jobs should run from a
+clean checkout of the same Git branch used for the analysis; generated results
+are stored outside the checkout.
+
 ## Results Summary
 
 ### RQ1: Deep NN vs Baseline (Table 1, Average Ratings)

--- a/reproduction/BASELINE_REPORT.md
+++ b/reproduction/BASELINE_REPORT.md
@@ -1,0 +1,81 @@
+# Art-paper baseline reproduction
+
+## Outcome
+
+The repository baseline is operational and reproduced closely enough to use as
+the reference implementation for the new experiments.
+
+- Repository: `hil-se/comparative_painting`
+- Commit: `b151e2e28870d836d7adaa120e9fc684acd94018`
+- Original model functions: unchanged
+- Features: repository's resized ResNet50 features (`origin=False`)
+- Split: 140 training images, remaining images for testing
+- Repetitions: fixed seeds 0–9
+- TIGRIS smoke job: `22260` (`COMPLETED`, exit `0:0`)
+- TIGRIS full job: `22262` (`COMPLETED`, exit `0:0`, elapsed 7m23s)
+- Hardware: one NVIDIA GH200, eight CPU cores
+- Software: RIT Spack environment `default-ml-aarch64-25050701`,
+  TensorFlow 2.16.1
+- Validation: 120/120 successful rows, 120 unique experiment keys, no
+  failures, no missing rows, no duplicates
+
+The deterministic OLS script also reproduced the repository's tracked values
+to floating-point precision.
+
+## Direct regression
+
+Each cell is `reproduced / repository`. Values are means across ten runs.
+
+| Painting | Rating | MAE | R² | Pearson ρ | Spearman rₛ |
+|---|---|---:|---:|---:|---:|
+| Abstract | Beauty | 0.6511 / 0.6161 | 0.3212 / 0.3847 | 0.5922 / 0.6490 | 0.5459 / 0.5938 |
+| Abstract | Liking | 0.5306 / 0.5068 | 0.2037 / 0.2770 | 0.4882 / 0.5631 | 0.4241 / 0.5020 |
+| Representational | Beauty | 0.5818 / 0.5604 | 0.3279 / 0.3435 | 0.6095 / 0.6310 | 0.6068 / 0.6173 |
+| Representational | Liking | 0.6101 / 0.5875 | 0.3646 / 0.4286 | 0.6229 / 0.6664 | 0.6097 / 0.6581 |
+
+## Comparative hinge model
+
+Each cell is `reproduced / repository`. MAE and R² are omitted because the
+encoder produces latent utilities that are not calibrated to the human rating
+scale.
+
+| Painting | Rating | N=1 Pearson ρ | N=1 Spearman rₛ | N=10 Pearson ρ | N=10 Spearman rₛ |
+|---|---|---:|---:|---:|---:|
+| Abstract | Beauty | 0.5402 / 0.5516 | 0.5154 / 0.5195 | 0.5729 / 0.6167 | 0.5179 / 0.5692 |
+| Abstract | Liking | 0.4538 / 0.4939 | 0.4146 / 0.4447 | 0.5111 / 0.5390 | 0.4389 / 0.4703 |
+| Representational | Beauty | 0.5531 / 0.5276 | 0.5469 / 0.5233 | 0.6020 / 0.6727 | 0.6118 / 0.6790 |
+| Representational | Liking | 0.5429 / 0.4877 | 0.5511 / 0.4772 | 0.6470 / 0.6654 | 0.6395 / 0.6568 |
+
+## Interpretation
+
+- The mean absolute difference in Pearson/Spearman correlation across the
+  reproduced and repository means is 0.0406; the maximum is 0.0779.
+- For the primary metrics—every regression metric plus comparative
+  correlations—31 of 32 repository differences are no larger than one
+  standard deviation of the reproduced runs. This is a descriptive
+  run-to-run comparison, not a formal significance test.
+- Exact neural equality is not expected because the repository does not record
+  the authors' random seeds and TIGRIS uses a newer TensorFlow/CUDA stack.
+- Comparative MAE and R² are extremely negative because pairwise hinge
+  utilities have an arbitrary offset and are not calibrated to the 1–9 rating
+  scale. Future hinge-versus-Bradley–Terry comparisons should use Pearson,
+  Spearman, pairwise accuracy, and/or fit a calibration mapping on training
+  data before reporting MAE/R².
+- Average-rating reproduction is unaffected by rater selection. Before
+  within-rater and cross-rater experiments, the intended cohort must be
+  resolved: the paper describes five raters, the regression runner selects ten,
+  and the bundled CSV files contain 43–49 individual rater columns.
+
+## Next implementation step
+
+Create one persisted split manifest for seeds 0–9 and make every condition use
+the same train/test indices. Then extract CLIP embeddings on TIGRIS and run a
+paired matrix:
+
+1. ResNet50 versus CLIP features;
+2. direct regression, hinge comparison, and Bradley–Terry comparison;
+3. abstract/representational × beauty/liking;
+4. the same metrics and identical splits for every method.
+
+This paired design isolates the effect of representation and loss function
+instead of confounding it with random data splits.

--- a/reproduction/README.md
+++ b/reproduction/README.md
@@ -1,0 +1,18 @@
+# Reproduction workflow
+
+This directory contains the deterministic baseline wrapper and the TIGRIS
+execution configuration used to validate the paper repository.
+
+- `run_art_average_baseline.py` calls the repository's original regression and
+  comparative experiment functions, adds fixed seeds, persists partial
+  results, and compares them with the tracked result tables.
+- `BASELINE_REPORT.md` records the completed baseline and its interpretation.
+- `cluster/` contains the Git-backed TIGRIS synchronization, smoke test, and
+  full Slurm job.
+
+Generated outputs are intentionally ignored by Git. Code and configuration
+move through GitHub; cluster logs, checkpoints, datasets not licensed for
+redistribution, and experiment outputs remain in cluster storage or an
+appropriate artifact store.
+
+See [`cluster/README.md`](cluster/README.md) for TIGRIS commands.

--- a/reproduction/cluster/README.md
+++ b/reproduction/cluster/README.md
@@ -1,0 +1,66 @@
+# TIGRIS execution
+
+The GitHub repository is the source of truth for code and Slurm
+configuration. TIGRIS keeps a clean checkout at
+`~/masters-art-repro/repo`; generated logs and results stay outside that
+checkout so `git pull --ff-only` remains safe.
+
+## One-time authentication
+
+TIGRIS requires an RIT password and Duo Mobile. Never store either credential
+in the repository. Register an SSH public key once, then verify it:
+
+```bash
+ssh-copy-id RIT_USERNAME@tigris.rc.rit.edu
+ssh -o BatchMode=yes RIT_USERNAME@tigris.rc.rit.edu hostname
+```
+
+## Inspect available resources
+
+```bash
+./reproduction/cluster/probe_tigris.sh RIT_USERNAME
+```
+
+Select a TIGRIS Slurm account reported by `my-accounts` and an ARM-compatible
+Spack environment containing GPU-enabled TensorFlow.
+
+## Sync without submitting
+
+Push the branch to GitHub first. From the repository root:
+
+```bash
+./reproduction/cluster/sync_tigris.sh \
+  RIT_USERNAME \
+  BRANCH
+```
+
+The first sync performs a partial-history clone of the branch. Later syncs use
+`git fetch`, `git switch`, and `git pull --ff-only`. The script refuses to
+overwrite a dirty TIGRIS checkout.
+
+## Sync and submit
+
+```bash
+./reproduction/cluster/submit_tigris.sh \
+  RIT_USERNAME \
+  SLURM_ACCOUNT \
+  SPACK_ML_ENV \
+  BRANCH
+```
+
+The wrapper syncs the exact GitHub branch, submits a short GH200 smoke test,
+then submits the full baseline with an `afterok` dependency. Each submission
+records the Git commit and uses a unique run ID.
+
+The default layout is:
+
+```text
+~/masters-art-repro/
+├── repo/       # clean Git checkout
+├── logs/       # Slurm stdout/stderr
+└── runs/       # results grouped by commit and submission time
+```
+
+The current baseline allocation is one GH200 GPU, eight CPU cores, 32 GB of
+CPU memory, and a two-hour wall time. Eight isolated TensorFlow workers share
+the GPU; each receives one CPU thread.

--- a/reproduction/cluster/probe_tigris.sh
+++ b/reproduction/cluster/probe_tigris.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 RIT_USERNAME" >&2
+    exit 2
+fi
+
+RIT_USERNAME="$1"
+TIGRIS_HOST="tigris.rc.rit.edu"
+TIGRIS_LOGIN="${RIT_USERNAME}@${TIGRIS_HOST}"
+
+echo "== Login host =="
+ssh -o BatchMode=yes "${TIGRIS_LOGIN}" hostname
+
+echo
+echo "== Architecture =="
+ssh -o BatchMode=yes "${TIGRIS_LOGIN}" uname -m
+
+echo
+echo "== Slurm accounts =="
+ssh -o BatchMode=yes "${TIGRIS_LOGIN}" 'bash -lc "my-accounts"'
+
+echo
+echo "== TIGRIS partitions and GPU resources =="
+ssh -o BatchMode=yes "${TIGRIS_LOGIN}" \
+    'bash -lc "sinfo --partition=tigris --format=%P,%a,%l,%D,%G"'
+
+echo
+echo "== Available Spack environments =="
+ssh -o BatchMode=yes "${TIGRIS_LOGIN}" 'bash -lc "spack env list"'

--- a/reproduction/cluster/submit_tigris.sh
+++ b/reproduction/cluster/submit_tigris.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 3 || $# -gt 5 ]]; then
+    echo "Usage: $0 RIT_USERNAME SLURM_ACCOUNT SPACK_ML_ENV [BRANCH] [REMOTE_ROOT]" >&2
+    exit 2
+fi
+
+RIT_USERNAME="$1"
+SLURM_ACCOUNT="$2"
+SPACK_ML_ENV="$3"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOSITORY_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BRANCH="${4:-$(git -C "${REPOSITORY_ROOT}" branch --show-current)}"
+REMOTE_ROOT="${5:-masters-art-repro}"
+TIGRIS_HOST="tigris.rc.rit.edu"
+TIGRIS_LOGIN="${RIT_USERNAME}@${TIGRIS_HOST}"
+
+for value in "${RIT_USERNAME}" "${SLURM_ACCOUNT}" "${SPACK_ML_ENV}" "${REMOTE_ROOT}"; do
+    if [[ ! "${value}" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+        echo "Unsafe or unsupported argument: ${value}" >&2
+        exit 2
+    fi
+done
+
+if [[ "${REMOTE_ROOT}" = /* || "${REMOTE_ROOT}" = *..* ]]; then
+    echo "REMOTE_ROOT must be a safe path relative to the TIGRIS home directory." >&2
+    exit 2
+fi
+
+if ! git check-ref-format --branch "${BRANCH}" >/dev/null; then
+    echo "Invalid Git branch: ${BRANCH}" >&2
+    exit 2
+fi
+
+"${SCRIPT_DIR}/sync_tigris.sh" \
+    "${RIT_USERNAME}" \
+    "${BRANCH}" \
+    "${REMOTE_ROOT}"
+
+ssh -o BatchMode=yes "${TIGRIS_LOGIN}" \
+    bash -s -- \
+    "${REMOTE_ROOT}" \
+    "${BRANCH}" \
+    "${SLURM_ACCOUNT}" \
+    "${SPACK_ML_ENV}" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+remote_root="$1"
+branch="$2"
+slurm_account="$3"
+spack_ml_env="$4"
+repository="${HOME}/${remote_root}/repo"
+log_directory="${HOME}/${remote_root}/logs"
+output_root="${HOME}/${remote_root}/runs"
+
+cd "${repository}"
+if [[ "$(git branch --show-current)" != "${branch}" ]]; then
+    echo "TIGRIS checkout is not on the requested branch: ${branch}" >&2
+    exit 2
+fi
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "TIGRIS checkout has uncommitted changes; refusing to submit." >&2
+    git status --short >&2
+    exit 2
+fi
+
+mkdir -p "${log_directory}" "${output_root}"
+commit="$(git rev-parse HEAD)"
+run_id="${commit:0:12}-$(date -u +%Y%m%dT%H%M%SZ)"
+
+smoke_job_id="$(
+    sbatch \
+        --parsable \
+        --account="${slurm_account}" \
+        --output="${log_directory}/%x_%j.out" \
+        --error="${log_directory}/%x_%j.err" \
+        --export="ALL,TIGRIS_REPO_ROOT=${repository},TIGRIS_OUTPUT_ROOT=${output_root},TIGRIS_RUN_ID=${run_id},TIGRIS_ML_ENV=${spack_ml_env}" \
+        reproduction/cluster/tigris_gpu_smoke.sbatch
+)"
+
+job_id="$(
+    sbatch \
+        --parsable \
+        --dependency="afterok:${smoke_job_id}" \
+        --account="${slurm_account}" \
+        --output="${log_directory}/%x_%j.out" \
+        --error="${log_directory}/%x_%j.err" \
+        --export="ALL,TIGRIS_REPO_ROOT=${repository},TIGRIS_OUTPUT_ROOT=${output_root},TIGRIS_RUN_ID=${run_id},TIGRIS_ML_ENV=${spack_ml_env}" \
+        reproduction/cluster/tigris_art_average_baseline.sbatch
+)"
+
+echo "Commit: ${commit}"
+echo "Run ID: ${run_id}"
+echo "Submitted smoke job ${smoke_job_id}."
+echo "Submitted dependent full job ${job_id}."
+echo "Monitor: squeue --job ${smoke_job_id},${job_id}"
+echo "Logs: ${log_directory}/"
+echo "Results: ${output_root}/${run_id}/"
+REMOTE_SCRIPT

--- a/reproduction/cluster/sync_tigris.sh
+++ b/reproduction/cluster/sync_tigris.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+    echo "Usage: $0 RIT_USERNAME [BRANCH] [REMOTE_ROOT]" >&2
+    exit 2
+fi
+
+RIT_USERNAME="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOSITORY_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BRANCH="${2:-$(git -C "${REPOSITORY_ROOT}" branch --show-current)}"
+REMOTE_ROOT="${3:-masters-art-repro}"
+REPOSITORY_URL="https://github.com/hil-se/comparative_painting.git"
+TIGRIS_LOGIN="${RIT_USERNAME}@tigris.rc.rit.edu"
+
+if [[ ! "${RIT_USERNAME}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "Invalid RIT username: ${RIT_USERNAME}" >&2
+    exit 2
+fi
+if [[ ! "${REMOTE_ROOT}" =~ ^[A-Za-z0-9._/-]+$ ]] ||
+    [[ "${REMOTE_ROOT}" = /* || "${REMOTE_ROOT}" = *..* ]]; then
+    echo "REMOTE_ROOT must be a safe path relative to the TIGRIS home directory." >&2
+    exit 2
+fi
+if ! git check-ref-format --branch "${BRANCH}" >/dev/null; then
+    echo "Invalid Git branch: ${BRANCH}" >&2
+    exit 2
+fi
+if ! git ls-remote --exit-code --heads "${REPOSITORY_URL}" \
+    "refs/heads/${BRANCH}" >/dev/null; then
+    echo "Branch is not available on GitHub: ${BRANCH}" >&2
+    echo "Push it before syncing TIGRIS." >&2
+    exit 2
+fi
+
+ssh -o BatchMode=yes "${TIGRIS_LOGIN}" \
+    bash -s -- \
+    "${REMOTE_ROOT}" \
+    "${BRANCH}" \
+    "${REPOSITORY_URL}" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+remote_root="$1"
+branch="$2"
+repository_url="$3"
+workspace="${HOME}/${remote_root}"
+repository="${workspace}/repo"
+
+mkdir -p "${workspace}/logs" "${workspace}/runs"
+
+if [[ ! -d "${repository}/.git" ]]; then
+    if [[ -e "${repository}" ]]; then
+        echo "Refusing to replace non-Git path: ${repository}" >&2
+        exit 2
+    fi
+    git clone \
+        --filter=blob:none \
+        --single-branch \
+        --branch "${branch}" \
+        "${repository_url}" \
+        "${repository}"
+else
+    cd "${repository}"
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "TIGRIS checkout has uncommitted changes; refusing to overwrite them." >&2
+        git status --short >&2
+        exit 2
+    fi
+    git fetch --prune origin
+    if git show-ref --verify --quiet "refs/heads/${branch}"; then
+        git switch "${branch}"
+    else
+        git switch --track -c "${branch}" "origin/${branch}"
+    fi
+    git pull --ff-only origin "${branch}"
+fi
+
+cd "${repository}"
+echo "TIGRIS repository: ${repository}"
+echo "Branch: $(git branch --show-current)"
+echo "Commit: $(git rev-parse HEAD)"
+REMOTE_SCRIPT

--- a/reproduction/cluster/tigris_art_average_baseline.sbatch
+++ b/reproduction/cluster/tigris_art_average_baseline.sbatch
@@ -1,0 +1,74 @@
+#!/bin/bash -l
+#SBATCH --job-name=art-avg-baseline
+#SBATCH --partition=tigris
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gres=gpu:gh200:1
+#SBATCH --mem=32G
+#SBATCH --time=02:00:00
+#SBATCH --output=logs/%x_%j.out
+#SBATCH --error=logs/%x_%j.err
+
+set -euo pipefail
+
+if [[ -z "${TIGRIS_REPO_ROOT:-}" ]]; then
+    echo "TIGRIS_REPO_ROOT was not exported by the submission wrapper." >&2
+    exit 2
+fi
+
+if [[ -z "${TIGRIS_ML_ENV:-}" ]]; then
+    echo "TIGRIS_ML_ENV was not exported by the submission wrapper." >&2
+    exit 2
+fi
+
+OUTPUT_ROOT="${TIGRIS_OUTPUT_ROOT:-${TIGRIS_REPO_ROOT}/reproduction/results}"
+RUN_ID="${TIGRIS_RUN_ID:-manual-${SLURM_JOB_ID}}"
+OUTPUT_DIRECTORY="${OUTPUT_ROOT}/${RUN_ID}/tigris_average_baseline_w8"
+CACHE_DIRECTORY="${OUTPUT_ROOT}/${RUN_ID}/.cache/matplotlib"
+
+cd "${TIGRIS_REPO_ROOT}"
+mkdir -p "${OUTPUT_DIRECTORY}" "${CACHE_DIRECTORY}"
+
+if ! command -v spack >/dev/null 2>&1; then
+    echo "Spack is unavailable in this login shell." >&2
+    exit 2
+fi
+
+spack env activate "${TIGRIS_ML_ENV}"
+
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python3)"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python)"
+else
+    echo "No Python executable is available in ${TIGRIS_ML_ENV}." >&2
+    exit 2
+fi
+
+export MPLCONFIGDIR="${CACHE_DIRECTORY}"
+export PYTHONUNBUFFERED=1
+export TF_CPP_MIN_LOG_LEVEL=2
+export TF_FORCE_GPU_ALLOW_GROWTH=true
+
+echo "Job ID: ${SLURM_JOB_ID}"
+echo "Node: $(hostname)"
+echo "Architecture: $(uname -m)"
+echo "Python: ${PYTHON_BIN}"
+echo "Spack environment: ${TIGRIS_ML_ENV}"
+echo "CUDA_VISIBLE_DEVICES: ${CUDA_VISIBLE_DEVICES:-unset}"
+nvidia-smi
+
+"${PYTHON_BIN}" -c \
+    'import numpy, pandas, scipy, sklearn, tensorflow as tf; devices=tf.config.list_physical_devices("GPU"); print("TensorFlow", tf.__version__, "GPUs", devices); assert devices, "TensorFlow did not detect the allocated GPU"'
+
+"${PYTHON_BIN}" reproduction/run_art_average_baseline.py \
+    --repo "${TIGRIS_REPO_ROOT}" \
+    --output "${OUTPUT_DIRECTORY}" \
+    --methods regression comparative \
+    --seeds 0:10 \
+    --n-values 1,10 \
+    --workers 8 \
+    --threads-per-worker 1
+
+echo "TIGRIS average-rating baseline completed successfully."

--- a/reproduction/cluster/tigris_gpu_smoke.sbatch
+++ b/reproduction/cluster/tigris_gpu_smoke.sbatch
@@ -1,0 +1,61 @@
+#!/bin/bash -l
+#SBATCH --job-name=art-gpu-smoke
+#SBATCH --partition=tigris
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --gres=gpu:gh200:1
+#SBATCH --mem=16G
+#SBATCH --time=00:20:00
+#SBATCH --output=logs/%x_%j.out
+#SBATCH --error=logs/%x_%j.err
+
+set -euo pipefail
+
+if [[ -z "${TIGRIS_REPO_ROOT:-}" || -z "${TIGRIS_ML_ENV:-}" ]]; then
+    echo "TIGRIS_REPO_ROOT and TIGRIS_ML_ENV must be exported." >&2
+    exit 2
+fi
+
+OUTPUT_ROOT="${TIGRIS_OUTPUT_ROOT:-${TIGRIS_REPO_ROOT}/reproduction/results}"
+RUN_ID="${TIGRIS_RUN_ID:-manual-${SLURM_JOB_ID}}"
+OUTPUT_DIRECTORY="${OUTPUT_ROOT}/${RUN_ID}/tigris_gpu_smoke"
+CACHE_DIRECTORY="${OUTPUT_ROOT}/${RUN_ID}/.cache/matplotlib"
+
+cd "${TIGRIS_REPO_ROOT}"
+mkdir -p "${OUTPUT_DIRECTORY}" "${CACHE_DIRECTORY}"
+spack env activate "${TIGRIS_ML_ENV}"
+
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python3)"
+else
+    PYTHON_BIN="$(command -v python)"
+fi
+
+export MPLCONFIGDIR="${CACHE_DIRECTORY}"
+export PYTHONUNBUFFERED=1
+export TF_CPP_MIN_LOG_LEVEL=2
+export TF_FORCE_GPU_ALLOW_GROWTH=true
+
+echo "Job ID: ${SLURM_JOB_ID}"
+echo "Node: $(hostname)"
+echo "Architecture: $(uname -m)"
+echo "Python: ${PYTHON_BIN}"
+echo "Spack environment: ${TIGRIS_ML_ENV}"
+nvidia-smi
+
+"${PYTHON_BIN}" -c \
+    'import numpy, pandas, scipy, sklearn, tensorflow as tf; devices=tf.config.list_physical_devices("GPU"); print("TensorFlow", tf.__version__, "GPUs", devices); assert devices, "TensorFlow did not detect the allocated GPU"'
+
+"${PYTHON_BIN}" reproduction/run_art_average_baseline.py \
+    --repo "${TIGRIS_REPO_ROOT}" \
+    --output "${OUTPUT_DIRECTORY}" \
+    --methods regression comparative \
+    --paintings abstract \
+    --rating-types beauty \
+    --seeds 0 \
+    --n-values 10 \
+    --workers 1 \
+    --threads-per-worker "${SLURM_CPUS_PER_TASK}"
+
+echo "TIGRIS GPU smoke test completed successfully."

--- a/reproduction/run_art_average_baseline.py
+++ b/reproduction/run_art_average_baseline.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""Reproduce the repository's average-rating art baselines with fixed seeds.
+
+The original experiment functions are imported and called unchanged. This
+wrapper adds only:
+
+* explicit seeds for Python, NumPy, and TensorFlow;
+* unique checkpoint names;
+* bounded process-level parallelism;
+* incremental raw-result persistence; and
+* comparison against the result CSVs tracked in the repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gc
+import importlib.metadata
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import random
+import statistics
+import subprocess
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime, timezone
+from multiprocessing import get_context
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_REPO = SCRIPT_DIR.parent
+DEFAULT_OUTPUT = SCRIPT_DIR / "results" / "average_baseline"
+
+PAINTINGS = ("abstract", "representational")
+RATING_TYPES = ("beauty", "liking")
+METRICS = ("mae", "r2", "rho", "rs")
+RAW_FIELDS = (
+    "method",
+    "painting",
+    "rating_type",
+    "N",
+    "seed",
+    "status",
+    "elapsed_seconds",
+    "mae",
+    "r2",
+    "rho",
+    "rs",
+    "error",
+)
+
+
+def parse_integer_spec(value: str) -> list[int]:
+    """Parse either ``start:stop`` or a comma-separated integer list."""
+    value = value.strip()
+    if ":" in value:
+        start_text, stop_text = value.split(":", maxsplit=1)
+        start, stop = int(start_text), int(stop_text)
+        if stop <= start:
+            raise argparse.ArgumentTypeError("range stop must be greater than start")
+        return list(range(start, stop))
+
+    values = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("at least one integer is required")
+    return values
+
+
+def task_key(row: dict[str, Any]) -> tuple[str, str, str, int | None, int]:
+    n_value = row.get("N")
+    if n_value in ("", None):
+        parsed_n = None
+    else:
+        parsed_n = int(n_value)
+    return (
+        str(row["method"]),
+        str(row["painting"]),
+        str(row["rating_type"]),
+        parsed_n,
+        int(row["seed"]),
+    )
+
+
+def run_task(task: dict[str, Any]) -> dict[str, Any]:
+    """Run one original repository experiment in an isolated worker."""
+    started = time.monotonic()
+    method = str(task["method"])
+    painting = str(task["painting"])
+    rating_type = str(task["rating_type"])
+    n_value = task.get("N")
+    seed = int(task["seed"])
+    threads_per_worker = int(task["threads_per_worker"])
+    repo = Path(str(task["repo"])).resolve()
+    deep_learning_dir = repo / "code" / "deep_learning"
+
+    result: dict[str, Any] = {
+        "method": method,
+        "painting": painting,
+        "rating_type": rating_type,
+        "N": "" if n_value is None else int(n_value),
+        "seed": seed,
+        "status": "error",
+        "elapsed_seconds": "",
+        "mae": "",
+        "r2": "",
+        "rho": "",
+        "rs": "",
+        "error": "",
+    }
+
+    try:
+        os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+        os.environ["TF_NUM_INTRAOP_THREADS"] = str(threads_per_worker)
+        os.environ["TF_NUM_INTEROP_THREADS"] = "1"
+        os.environ["OMP_NUM_THREADS"] = str(threads_per_worker)
+        os.environ.setdefault(
+            "MPLCONFIGDIR", "/private/tmp/codex-mpl-comparative-painting"
+        )
+
+        os.chdir(deep_learning_dir)
+        if str(deep_learning_dir) not in sys.path:
+            sys.path.insert(0, str(deep_learning_dir))
+
+        import numpy as np
+        import tensorflow as tf
+
+        tf.get_logger().setLevel("ERROR")
+        tf.keras.backend.clear_session()
+        tf.keras.utils.set_random_seed(seed)
+        random.seed(seed)
+        np.random.seed(seed)
+
+        process_id = (
+            f"repro_{method}_{painting}_{rating_type}_"
+            f"n{n_value if n_value is not None else 'na'}_s{seed}_{os.getpid()}"
+        )
+
+        if method == "regression":
+            from experiment_runner import average_rating
+
+            metrics = average_rating(
+                painting,
+                rating_type,
+                origin=False,
+                process_id=process_id,
+            )
+        elif method == "comparative":
+            from comparitive_experiments import average_rating
+
+            metrics = average_rating(
+                painting,
+                rating_type,
+                origin=False,
+                N=int(n_value),
+                process_id=process_id,
+            )
+        else:
+            raise ValueError(f"unsupported method: {method}")
+
+        for metric in METRICS:
+            result[metric] = float(metrics[metric])
+        result["status"] = "ok"
+    except Exception as exc:
+        result["error"] = f"{type(exc).__name__}: {exc}"
+    finally:
+        result["elapsed_seconds"] = round(time.monotonic() - started, 3)
+        try:
+            import tensorflow as tf
+
+            tf.keras.backend.clear_session()
+        except Exception:
+            pass
+        gc.collect()
+
+    return result
+
+
+def read_raw_results(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]], fields: tuple[str, ...]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+    temporary.replace(path)
+
+
+def build_tasks(
+    repo: Path,
+    methods: list[str],
+    paintings: list[str],
+    rating_types: list[str],
+    seeds: list[int],
+    n_values: list[int],
+    threads_per_worker: int,
+) -> list[dict[str, Any]]:
+    tasks: list[dict[str, Any]] = []
+    for method in methods:
+        for painting in paintings:
+            for rating_type in rating_types:
+                method_n_values: tuple[int | None, ...]
+                if method == "comparative":
+                    method_n_values = tuple(n_values)
+                else:
+                    method_n_values = (None,)
+                for n_value in method_n_values:
+                    for seed in seeds:
+                        tasks.append(
+                            {
+                                "method": method,
+                                "painting": painting,
+                                "rating_type": rating_type,
+                                "N": n_value,
+                                "seed": seed,
+                                "repo": str(repo),
+                                "threads_per_worker": threads_per_worker,
+                            }
+                        )
+    return tasks
+
+
+def summarize(rows: list[dict[str, Any]], expected_runs: int) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str, str, int | None], list[dict[str, Any]]] = {}
+    for row in rows:
+        if row.get("status") != "ok":
+            continue
+        key = task_key(row)[:4]
+        groups.setdefault(key, []).append(row)
+
+    summary_rows: list[dict[str, Any]] = []
+    for key in sorted(
+        groups,
+        key=lambda item: (item[0], item[1], item[2], -1 if item[3] is None else item[3]),
+    ):
+        method, painting, rating_type, n_value = key
+        group = groups[key]
+        summary: dict[str, Any] = {
+            "method": method,
+            "painting": painting,
+            "rating_type": rating_type,
+            "N": "" if n_value is None else n_value,
+            "n_success": len(group),
+            "n_expected": expected_runs,
+        }
+        for metric in METRICS:
+            values = [float(row[metric]) for row in group]
+            summary[f"{metric}_mean"] = statistics.fmean(values)
+            summary[f"{metric}_std"] = (
+                statistics.stdev(values) if len(values) > 1 else 0.0
+            )
+        summary_rows.append(summary)
+    return summary_rows
+
+
+def read_reference(
+    repo: Path,
+    method: str,
+    painting: str,
+    rating_type: str,
+    n_value: int | None,
+) -> dict[str, float] | None:
+    if method == "regression":
+        path = (
+            repo
+            / "results"
+            / "deep_learning"
+            / "regression"
+            / f"{painting}_{rating_type}_average.csv"
+        )
+    else:
+        path = (
+            repo
+            / "results"
+            / "deep_learning"
+            / "comparative"
+            / f"{painting}_{rating_type}_average_comparative.csv"
+        )
+
+    if not path.exists():
+        return None
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+
+    if method == "comparative":
+        matches = [row for row in rows if int(float(row["N"])) == int(n_value)]
+        if not matches:
+            return None
+        source = matches[0]
+    elif rows:
+        source = rows[0]
+    else:
+        return None
+    return {metric: float(source[metric]) for metric in METRICS}
+
+
+def compare_with_repository(
+    repo: Path, summary_rows: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    comparison: list[dict[str, Any]] = []
+    for row in summary_rows:
+        n_value = None if row["N"] == "" else int(row["N"])
+        reference = read_reference(
+            repo,
+            str(row["method"]),
+            str(row["painting"]),
+            str(row["rating_type"]),
+            n_value,
+        )
+        if reference is None:
+            continue
+        for metric in METRICS:
+            reproduced = float(row[f"{metric}_mean"])
+            repository_value = reference[metric]
+            comparison.append(
+                {
+                    "method": row["method"],
+                    "painting": row["painting"],
+                    "rating_type": row["rating_type"],
+                    "N": row["N"],
+                    "metric": metric,
+                    "reproduced_mean": reproduced,
+                    "reproduced_std": row[f"{metric}_std"],
+                    "repository_mean": repository_value,
+                    "delta": reproduced - repository_value,
+                    "absolute_delta": abs(reproduced - repository_value),
+                }
+            )
+    return comparison
+
+
+def git_commit(repo: Path) -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else "unknown"
+
+
+def package_versions() -> dict[str, str]:
+    packages = (
+        "tensorflow",
+        "numpy",
+        "pandas",
+        "scipy",
+        "statsmodels",
+        "scikit-learn",
+        "matplotlib",
+    )
+    versions: dict[str, str] = {}
+    for package in packages:
+        try:
+            versions[package] = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            versions[package] = "not installed"
+    return versions
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=DEFAULT_REPO)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--methods",
+        nargs="+",
+        choices=("regression", "comparative"),
+        default=["regression", "comparative"],
+    )
+    parser.add_argument(
+        "--paintings",
+        nargs="+",
+        choices=PAINTINGS,
+        default=list(PAINTINGS),
+    )
+    parser.add_argument(
+        "--rating-types",
+        nargs="+",
+        choices=RATING_TYPES,
+        default=list(RATING_TYPES),
+    )
+    parser.add_argument(
+        "--seeds",
+        type=parse_integer_spec,
+        default=list(range(10)),
+        help="Either start:stop or comma-separated integers (default: 0:10).",
+    )
+    parser.add_argument(
+        "--n-values",
+        type=parse_integer_spec,
+        default=[1, 10],
+        help="Comparative N values (default: 1,10).",
+    )
+    parser.add_argument("--workers", type=int, default=3)
+    parser.add_argument(
+        "--threads-per-worker",
+        type=int,
+        default=3,
+        help="TensorFlow intra-op CPU threads assigned to each worker (default: 3).",
+    )
+    parser.add_argument(
+        "--no-resume",
+        action="store_true",
+        help="Ignore completed rows already present in raw_results.csv.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo = args.repo.resolve()
+    output = args.output.resolve()
+    raw_path = output / "raw_results.csv"
+    summary_path = output / "summary.csv"
+    comparison_path = output / "comparison_to_repository.csv"
+    metadata_path = output / "metadata.json"
+
+    if not (repo / "code" / "deep_learning").is_dir():
+        raise SystemExit(f"repository not found or incomplete: {repo}")
+    if args.workers < 1:
+        raise SystemExit("--workers must be at least 1")
+    if args.threads_per_worker < 1:
+        raise SystemExit("--threads-per-worker must be at least 1")
+
+    output.mkdir(parents=True, exist_ok=True)
+    all_tasks = build_tasks(
+        repo,
+        args.methods,
+        args.paintings,
+        args.rating_types,
+        args.seeds,
+        args.n_values,
+        args.threads_per_worker,
+    )
+    existing_rows = [] if args.no_resume else read_raw_results(raw_path)
+    completed_keys = {
+        task_key(row) for row in existing_rows if row.get("status") == "ok"
+    }
+    pending = [task for task in all_tasks if task_key(task) not in completed_keys]
+
+    metadata = {
+        "created_or_resumed_utc": datetime.now(timezone.utc).isoformat(),
+        "repository": str(repo),
+        "repository_commit": git_commit(repo),
+        "model_code_modified": False,
+        "feature_variant": "resized (origin=False)",
+        "train_size": 140,
+        "methods": args.methods,
+        "paintings": args.paintings,
+        "rating_types": args.rating_types,
+        "seeds": args.seeds,
+        "comparative_N_values": args.n_values,
+        "workers": args.workers,
+        "threads_per_worker": args.threads_per_worker,
+        "python": sys.version,
+        "platform": platform.platform(),
+        "package_versions": package_versions(),
+        "notes": [
+            "Calls the repository's average_rating functions unchanged.",
+            "Seeds were not supplied by the repository; this run fixes seeds explicitly.",
+            "Comparative MAE/R2 are retained for fidelity, but raw hinge utilities have arbitrary offset and scale.",
+        ],
+    }
+    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Repository: {repo}", flush=True)
+    print(f"Output: {output}", flush=True)
+    print(
+        f"Tasks: {len(all_tasks)} total, {len(completed_keys)} already complete, "
+        f"{len(pending)} pending; workers={args.workers}, "
+        f"threads_per_worker={args.threads_per_worker}",
+        flush=True,
+    )
+
+    results_by_key: dict[
+        tuple[str, str, str, int | None, int], dict[str, Any]
+    ] = {task_key(row): row for row in existing_rows}
+
+    if pending:
+        context = get_context("spawn")
+        with ProcessPoolExecutor(
+            max_workers=args.workers,
+            mp_context=context,
+        ) as executor:
+            future_to_task = {
+                executor.submit(run_task, task): task for task in pending
+            }
+            finished = len(completed_keys)
+            for future in as_completed(future_to_task):
+                task = future_to_task[future]
+                try:
+                    row = future.result()
+                except Exception as exc:
+                    row = {
+                        **task,
+                        "N": "" if task["N"] is None else task["N"],
+                        "status": "error",
+                        "elapsed_seconds": "",
+                        "mae": "",
+                        "r2": "",
+                        "rho": "",
+                        "rs": "",
+                        "error": f"worker failure: {type(exc).__name__}: {exc}",
+                    }
+                results_by_key[task_key(row)] = row
+                finished += 1
+                ordered_rows = sorted(
+                    results_by_key.values(),
+                    key=lambda item: (
+                        str(item["method"]),
+                        str(item["painting"]),
+                        str(item["rating_type"]),
+                        -1 if item.get("N") in ("", None) else int(item["N"]),
+                        int(item["seed"]),
+                    ),
+                )
+                write_csv(raw_path, ordered_rows, RAW_FIELDS)
+
+                label_n = "" if task["N"] is None else f" N={task['N']}"
+                if row["status"] == "ok":
+                    print(
+                        f"[{finished}/{len(all_tasks)}] {task['method']} "
+                        f"{task['painting']} {task['rating_type']}{label_n} "
+                        f"seed={task['seed']} rho={float(row['rho']):.4f} "
+                        f"rs={float(row['rs']):.4f} "
+                        f"({float(row['elapsed_seconds']):.1f}s)",
+                        flush=True,
+                    )
+                else:
+                    print(
+                        f"[{finished}/{len(all_tasks)}] ERROR {task['method']} "
+                        f"{task['painting']} {task['rating_type']}{label_n} "
+                        f"seed={task['seed']}: {row['error']}",
+                        flush=True,
+                    )
+
+    final_rows = sorted(
+        results_by_key.values(),
+        key=lambda item: (
+            str(item["method"]),
+            str(item["painting"]),
+            str(item["rating_type"]),
+            -1 if item.get("N") in ("", None) else int(item["N"]),
+            int(item["seed"]),
+        ),
+    )
+    write_csv(raw_path, final_rows, RAW_FIELDS)
+    summary_rows = summarize(final_rows, expected_runs=len(args.seeds))
+    summary_fields = (
+        "method",
+        "painting",
+        "rating_type",
+        "N",
+        "n_success",
+        "n_expected",
+        *(f"{metric}_{suffix}" for metric in METRICS for suffix in ("mean", "std")),
+    )
+    write_csv(summary_path, summary_rows, tuple(summary_fields))
+
+    comparisons = compare_with_repository(repo, summary_rows)
+    comparison_fields = (
+        "method",
+        "painting",
+        "rating_type",
+        "N",
+        "metric",
+        "reproduced_mean",
+        "reproduced_std",
+        "repository_mean",
+        "delta",
+        "absolute_delta",
+    )
+    write_csv(comparison_path, comparisons, comparison_fields)
+
+    failures = [row for row in final_rows if row.get("status") != "ok"]
+    missing = len(all_tasks) - sum(
+        1 for task in all_tasks if task_key(task) in results_by_key
+    )
+    print(
+        f"Finished: {len(final_rows) - len(failures)} successful rows, "
+        f"{len(failures)} failed rows, {missing} missing rows.",
+        flush=True,
+    )
+    print(f"Summary: {summary_path}", flush=True)
+    print(f"Comparison: {comparison_path}", flush=True)
+    return 0 if not failures and missing == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- add the fixed-seed baseline reproduction wrapper and completed validation report
- add a Git-backed TIGRIS sync workflow using a clean checkout at `~/masters-art-repro/repo`
- keep Slurm logs and experiment outputs outside the checkout under `~/masters-art-repro/logs` and `~/masters-art-repro/runs`
- add GH200 smoke and full baseline jobs with commit-tagged run IDs
- document the workflow and ignore generated cluster artifacts

## Why

Using GitHub as the source of truth keeps local development and TIGRIS on the
same reviewed commit, while separating generated outputs prevents cluster runs
from dirtying the checkout or blocking fast-forward updates.

## Validation

- `bash -n` on all shell and Slurm scripts
- `python3 -m py_compile reproduction/run_art_average_baseline.py`
- runner CLI help check
- `.gitignore` behavior checked for results, logs, and run directories
- staged diff checked with `git diff --cached --check`
- TIGRIS clone and repeat fast-forward sync both resolved to commit
  `4b2c5c75195f856c48f03ecbf45bb26ff7dae0db`
- TIGRIS GH200 smoke job `22270` completed with exit `0:0` in 52 seconds:
  2/2 experiment rows succeeded, result metadata recorded the same commit, and
  the cluster checkout remained clean

The four pre-existing tracked `.DS_Store` modifications were intentionally
excluded.
